### PR TITLE
Added stop-words required package in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 gensim
 nltk
 rank_bm25
+stop-words


### PR DESCRIPTION
In trying to run `example.py`, there was an error saying that the `stop_words` module can't be found (it is used in `gensim_topic_modelling.py`. Added the stop-words package requirement in `requirements.txt`.